### PR TITLE
Fix back button behaviour on queue list

### DIFF
--- a/mobile/src/main/java/se/kth/csc/stayawhile/MainActivity.java
+++ b/mobile/src/main/java/se/kth/csc/stayawhile/MainActivity.java
@@ -71,6 +71,7 @@ public class MainActivity extends AppCompatActivity {
                     editor.putString("userData", result);
                     editor.apply();
                     Intent queueList = new Intent(MainActivity.this, QueueListActivity.class);
+                    queueList.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_TASK_ON_HOME);
                     startActivity(queueList);
                 }
             }).execute("method", "userData");
@@ -79,6 +80,12 @@ public class MainActivity extends AppCompatActivity {
         } catch (ExecutionException e) {
             e.printStackTrace();
         }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        finish();
     }
 
     @Override


### PR DESCRIPTION
When pressing the back button on the queue list, you are currently taken back to the login page. Instead, exit the application.
