### PR TITLE
Smallfixes

### DIFF
--- a/mobile/src/main/java/se/kth/csc/stayawhile/QueueActivity.java
+++ b/mobile/src/main/java/se/kth/csc/stayawhile/QueueActivity.java
@@ -144,12 +144,6 @@ public class QueueActivity extends AppCompatActivity implements MessageDialogFra
         mGoogleApiClient = new GoogleApiClient.Builder(this)
                 .addApi(Wearable.API)
                 .build();
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        mGoogleApiClient.connect();
 
         // Message API
         Wearable.MessageApi.addListener(mGoogleApiClient, new MessageApi.MessageListener() {
@@ -169,6 +163,11 @@ public class QueueActivity extends AppCompatActivity implements MessageDialogFra
                     sendQueueUpdate();
             }
         });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
         mGoogleApiClient.connect();
     }
 

--- a/mobile/src/main/java/se/kth/csc/stayawhile/QueueActivity.java
+++ b/mobile/src/main/java/se/kth/csc/stayawhile/QueueActivity.java
@@ -471,9 +471,21 @@ public class QueueActivity extends AppCompatActivity implements MessageDialogFra
     }
 
     @Override
+    public void onBackPressed() {
+        Intent intent = new Intent(this, MainActivity.class);
+        this.finish();
+        startActivity(intent);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         final int id = item.getItemId();
         switch (id) {
+            case android.R.id.home:
+                Intent intent = new Intent(this, MainActivity.class);
+                this.finish();
+                startActivity(intent);
+                return true;
             case R.id.action_broadcast:
             case R.id.action_broadcast_faculty:
                 MessageDialogFragment fragment = new MessageDialogFragment();

--- a/wear/src/main/java/se/kth/csc/stayawhile/MainActivity.java
+++ b/wear/src/main/java/se/kth/csc/stayawhile/MainActivity.java
@@ -1,5 +1,6 @@
 package se.kth.csc.stayawhile;
 
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -18,10 +19,12 @@ import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataEvent;
 import com.google.android.gms.wearable.DataEventBuffer;
 import com.google.android.gms.wearable.DataItem;
+import com.google.android.gms.wearable.DataItemBuffer;
 import com.google.android.gms.wearable.DataMap;
 import com.google.android.gms.wearable.DataMapItem;
 import com.google.android.gms.wearable.MessageApi;
 import com.google.android.gms.wearable.Node;
+import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
 import org.json.JSONArray;
@@ -83,6 +86,24 @@ public class MainActivity extends WearableActivity {
                     @Override
                     public void onConnected(@Nullable Bundle bundle) {
                         Wearable.DataApi.addListener(mGoogleApiClient, onDataChangeListener);
+
+                        Uri uri = new Uri.Builder()
+                                .scheme(PutDataRequest.WEAR_URI_SCHEME)
+                                .path("/stayawhile/queue")
+                                .build();
+
+                        Wearable.DataApi.getDataItems(mGoogleApiClient, uri)
+                                .setResultCallback(new ResultCallback<DataItemBuffer>() {
+                                                       @Override
+                                                       public void onResult(DataItemBuffer items) {
+                                                           for(int i=0;i<items.getCount();i++) {
+                                                               DataItem item = items.get(i);
+                                                               DataMap dataMap = DataMapItem.fromDataItem(item).getDataMap();
+                                                               queueUpdated(dataMap.getString(QUEUE_KEY));
+                                                           }
+                                                       }
+                                                   }
+                                );
                     }
 
                     @Override


### PR DESCRIPTION
föreslår dessa förändringar, de ligger i avtagande viktighetsordning, så den sista är minst viktig. är samma sak som fanns i svedi-random branchen

i head på master atm så när man öppnar klockan från att ha gått ut till "skrivbordet" så visas inte kön, utan man måste vänta på en event för att den ska visas på klockan.

andra grejen gör så man startar mainactivity när man trycker på bakåt knappen i queueactivity. om man startar queue activity och sedan går ur appen och sedan tillbaka till appen, så finns det annars (mig veterligen) inget sätt att komma tillbaka till queuelistactivity, utom att stänga av appen och sedan starta den

sista commiten är bara att flytta grejer för det känns konstigt att lägga till en listener på varje resume, men jag har egentligen ingen aning om det är bra eller så. den här diffen ser helt galen ut också, men den flyttar alltså kod som inte syns i diffen.
